### PR TITLE
Added touch option to extraction (for hosts with out-of-sync clocks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ grunt.initConfig({
       dest : "/path/on/server",
       server_sep : "/",
       clean : true,
+	  touch : false,
       exclusions : ['important', 'dont.touch'],
       auth: {
         host : 'yourdomain.com',
@@ -64,6 +65,12 @@ Type: `Boolean`
 Default value: `false`
 
 Determines whether to clean location on server before putting there the new version.
+
+#### touch
+Type: `Boolean`
+Default value: `false`
+
+Set to true to prevent extraction of file modified time. 
 
 #### exclusions
 Type: `Array<String>`

--- a/tasks/compress-deploy.js
+++ b/tasks/compress-deploy.js
@@ -234,9 +234,10 @@ module.exports = function(grunt) {
 
   function extractArchive(options, ssh) {
     var self = this;
+    var touchOption = options.touch ? 'm' : '';
 
     var command = 'cd '+getRootPath(options)+' && '+
-                  'tar -xzf ' + options.archive_name + ' --strip-components 1';
+                  'tar -' + touchOption + 'xzf ' + options.archive_name + ' --strip-components 1';
 
     handleCommand(ssh, command, 'Decompressing the archive', function (done) {
       done();


### PR DESCRIPTION
I'm having some trouble with out host having a out of sync clock which causes extraction to fail due to the timestamps being in the future. Adding the '-m'  to tar command is a workaround for this problem as.
